### PR TITLE
Better sourcemaps support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 var loaderUtils = require('loader-utils');
 var postcss     = require('postcss');
 
-module.exports = function (source) {
+module.exports = function (source, map) {
     if ( this.cacheable ) this.cacheable();
 
     var file    = loaderUtils.getRemainingRequest(this);
     var params  = loaderUtils.parseQuery(this.query);
 
-    var opts = { from: file, to: file };
+    var opts = { from: file, to: file, map: { prev: map, inline: false } };
     if ( params.safe ) opts.safe = true;
 
     var processors = this.options.postcss;


### PR DESCRIPTION
This fixes source mapping when used with sass-loader.

Also, we don't want to map to the postcss generated source, we want to map to the pre-postcss source, so this is also an improvement for CSS source maps.

Inline source maps can be generated using `devtool: 'inline-source-map'`. 