### PR TITLE
Fixed invalid sourcemap exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function (source, map) {
             annotation: false
         }
     };
-    if ( map ) opts.map.prev     = map;
+    if ( map && map.mappings ) opts.map.prev = map;
     if ( params.safe ) opts.safe = true;
 
     var plugins = this.options.postcss;


### PR DESCRIPTION
PostCSS was throwing "Unsupported previous source map format" error in situations where a sass file was compiled without any output. (For example a scss file that contained an empty selector.)