### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Set `postcss` section in webpack config:
 
 ```js
 var autoprefixer = require('autoprefixer');
-var precs s      = require('precss');
+var precss      = require('precss');
 
 module.exports = {
     module: {


### PR DESCRIPTION
Just removed the space from the `precs s` in the README