### PR TITLE
Return proper sourcemap instead of SourceMapGenerator

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function (source, map) {
             result.warnings().forEach(function (msg) {
                 loader.emitWarning(msg.toString());
             });
-            callback(null, result.css, result.map);
+            callback(null, result.css, result.map.toJSON());
         })
         .catch(function (error) {
             if ( error.name === 'CssSyntaxError' ) {


### PR DESCRIPTION
From https://webpack.github.io/docs/how-to-write-a-loader.html, on the subject of loaders returning sourcemaps:

> The loader is expected to give back one or two values. ... The second optional value is a SourceMap as JavaScript object.

However, postcss-loader returns an instance of SourceMapGenerator
https://github.com/postcss/postcss-loader/blob/master/index.js#L51

This may break subsequent loaders that are expecting to receive a sourcemap.