### PR TITLE
Add capability to pass other options as function

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,25 @@ var css = require('postcss?parser=postcss-safe-parser!./broken')
 ```
 
 [Safe Parser]: https://github.com/postcss/postcss-safe-parser
+
+If you need to pass the function directly instead of a module name, you can do so through the webpack postcss option, as such:
+
+```js
+var sugarss = require('sugarss')
+module.exports = {
+    module: {
+        loaders: [
+            {
+                test:   /\.css$/,
+                loader: "style-loader!css-loader!postcss-loader"
+            }
+        ]
+    },
+    postcss: function () {
+        return {
+            plugins: [autoprefixer, precss],
+            syntax: sugarss
+        };
+    }
+}
+```

--- a/index.js
+++ b/index.js
@@ -19,21 +19,31 @@ module.exports = function (source, map) {
     if ( typeof map === 'string' ) map = JSON.parse(map);
     if ( map && map.mappings ) opts.map.prev = map;
 
-    if ( params.syntax )      opts.syntax      = require(params.syntax);
-    if ( params.parser )      opts.parser      = require(params.parser);
-    if ( params.stringifier ) opts.stringifier = require(params.stringifier);
-
-    var plugins = this.options.postcss;
-    if ( typeof plugins === 'function' ) {
-        plugins = plugins.call(this, this);
+    var plugins;
+    var options = this.options.postcss;
+    if ( typeof options === 'function' ) {
+        options = options.call(this, this);
     }
 
-    if ( typeof plugins === 'undefined' ) {
+    if ( typeof options === 'undefined' ) {
         plugins = [];
     } else if ( params.pack ) {
-        plugins = plugins[params.pack];
-    } else if ( !Array.isArray(plugins) ) {
-        plugins = plugins.defaults;
+        plugins = options[params.pack];
+    } else if ( !Array.isArray(options) ) {
+        plugins = options.plugins || options.defaults;
+        opts.syntax = options.syntax;
+        opts.parser = options.parser;
+        opts.stringifier = options.stringifier;
+    }
+
+    if ( params.syntax && !opts.syntax ) {
+        opts.syntax = require(params.syntax);
+    }
+    if ( params.parser && !opts.parser ) {
+        opts.parser = require(params.parser);
+    }
+    if ( params.stringifier && !opts.stringifier ) {
+        opts.stringifier = require(params.stringifier);
     }
 
     var loader   = this;


### PR DESCRIPTION
In its current implementation, `parser`, `syntax`, and `stringifier` can only be passed as string which are required internally. This patch allows users to pass in any of these options as a function instead of a string, which is important to be able to do if the option is passed from elsewhere and not required directly as is done internally.

This patch is made in a manner that is non-breaking, although honestly making a breaking change to the way options are handled would provide a much cleaner syntax and easier user experience. If you're open to breaking changes, I'd be happy to modify this -- my proposal would be to just have the postcss webpack option always ask for an object or function that returns an object. This way we have a flexible data structure that's able to accommodate whatever the user needs to pass, it's expandable for future options, and all the config is in one place instead of spread across querystrings and webpack options. For example:

```js
module.exports = {
  loaders: [...],
  postcss: {
    plugins: [...],
    syntax: someModule
    // and any number of other options
  }
}
```