### PR TITLE
Update README.md to fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Now your CSS files requirements will be processed by selected PostCSS plugins:
 
 ```js
 var css = require('./file.css');
-// => CSS after Autoprefixer and CSSWring
+// => CSS after PreCSS and Autoprefixer
 ```
 
 Note that the context of this function


### PR DESCRIPTION
A comment in the example code refers to the CSSWring plugin but it should be PreCSS instead.