### PR TITLE
Consistent format for CSS syntax errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "repository": "postcss/postcss-loader",
   "dependencies": {
+    "babel-code-frame": "^6.11.0",
     "loader-utils": "^0.2.15",
     "postcss":      "^5.1.2"
   },


### PR DESCRIPTION
I used `babel-code-frame` package formatting syntax errors code frames. That makes it consistent with Babel output which is I think very important as it makes it less cognitive efforts to recognize and process the error. Also code frames are a little bit fancies now (shows the line numebrs) so probably PostCSS itself should adopt this style.

You can also see that there's no duplicated filename in error message as webpack already print module name.

Before:

<img width="1278" alt="screenshot 2016-08-15 19 40 31" src="https://cloud.githubusercontent.com/assets/30594/17671533/259bd08a-6320-11e6-84c9-4a2c6bbab468.png">

After:

<img width="314" alt="screenshot 2016-08-15 19 39 19" src="https://cloud.githubusercontent.com/assets/30594/17671498/f987a078-631f-11e6-9bf4-840e51138bb1.png">
