### PR TITLE
Add postcss-loader-before-processing event

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,4 +290,15 @@ export default {
 }
 ```
 
+
+### Webpack Events
+
+Webpack provides webpack-plugin developers a convenient way to hook into the build pipeline.
+The postcss-loader makes us of this event system to allow building integrated postcss-webpack tools.
+
+See the [example implementation](https://github.com/postcss/postcss-loader/blob/master/test/webpack-plugins/rewrite.js)
+
+* `postcss-loader-before-processing`  
+  is fired before processing and allows to add or remove postcss plugins
+
 [postcss-js]: https://github.com/postcss/postcss-js

--- a/index.js
+++ b/index.js
@@ -85,6 +85,13 @@ module.exports = function (source, map) {
         source = this.exec(source, this.resource);
     }
 
+    // Allow plugins to add or remove postcss plugins
+    plugins = this._compilation.applyPluginsWaterfall(
+        'postcss-loader-before-processing',
+        [].concat(plugins),
+        params
+    );
+
     postcss(plugins).process(source, opts)
         .then(function (result) {
             result.warnings().forEach(function (msg) {

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,11 @@ describe('postcss-loader', function () {
         expect(css).to.eql('a { color:\n}');
     });
 
+    it('lets other plugins alter the used plugins', function () {
+        var css = require('!raw-loader!../?rewrite=true!./cases/style.css');
+        expect(css).to.eql('a { color: black }\n');
+    });
+
     it('processes CSS-in-JS', function () {
         var css = require('!raw-loader!' +
                           '../?parser=postcss-js!' +

--- a/test/webpack-plugins/rewrite.js
+++ b/test/webpack-plugins/rewrite.js
@@ -1,0 +1,21 @@
+function RewritePlugin() {
+
+}
+
+RewritePlugin.prototype.apply = function (compiler) {
+    function rewrite(postcssPlugins, loaderParams) {
+        // Just for the demo and test we remove all plugins if
+        // the 'rewrite' parameter is set
+        if (loaderParams.rewrite) {
+            return [];
+        }
+        // If the rewrite parameter isn't set we don't change the modules
+        return postcssPlugins;
+    }
+
+    compiler.plugin('compilation', function (compilation) {
+        compilation.plugin('postcss-loader-before-processing', rewrite);
+    });
+};
+
+module.exports = RewritePlugin;

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -2,6 +2,7 @@ var path = require('path');
 
 var blue = require('./plugins/blue');
 var red  = require('./plugins/red');
+var RewritePlugin = require('./webpack-plugins/rewrite.js');
 
 module.exports = {
     target:  'node',
@@ -16,5 +17,8 @@ module.exports = {
             defaults: [blue, red],
             blues:    [blue]
         };
-    }
+    },
+    plugins: [
+        new RewritePlugin()
+    ]
 };


### PR DESCRIPTION
This pull request introduces a new feature.

It allows third party webpack plugins to add or remove postcss plugins using the `postcss-loader-before-processing` event (using the webpack built in plugin system).

An example can be seen here:
https://github.com/jantimon/postcss-loader/blob/33436d715119258053e5459b7cfde26eeecd0aa1/test/webpack-plugins/rewrite.js

Motivation:
There are cases where a postcss plugin is very tight cupeled with a webpack plugin as it has to access the webpack internals.
In this case it would be nice if this webpack could also add its postcss part to the loader.