### PR TITLE
Runaway promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ module.exports = function (source, map) {
                 loader.emitWarning(msg.toString());
             });
             callback(null, result.css, result.map ? result.map.toJSON() : null);
+            return null;
         })
         .catch(function (error) {
             if ( error.name === 'CssSyntaxError' ) {


### PR DESCRIPTION
In conjunction with bluebird, I get a couple of Warnings:

> `Warning: a promise was created in a handler at usr/app/node_modules/postcss-loader/index.js:100:13 but was not returned from it, see http://goo.gl/rRqMUw`

[Documentation](http://goo.gl/rRqMUw) states that one should at least `return null` to "signal that we didn't forget to return".