### PR TITLE
Allow control over loader `exec`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ module.exports = function (source, map) {
     }
 
     var plugins;
+    var exec;
     if ( typeof options === 'undefined' ) {
         plugins = [];
     } else if ( Array.isArray(options) ) {
@@ -60,6 +61,7 @@ module.exports = function (source, map) {
         opts.stringifier = options.stringifier;
         opts.parser      = options.parser;
         opts.syntax      = options.syntax;
+        exec             = options.exec;
     }
     if ( params.pack ) {
         plugins = options[params.pack];
@@ -77,11 +79,14 @@ module.exports = function (source, map) {
     if ( params.stringifier ) {
         opts.stringifier = require(params.stringifier);
     }
+    if ( params.exec ) {
+        exec = params.exec;
+    }
 
     var loader   = this;
     var callback = this.async();
 
-    if ( params.parser === 'postcss-js' ) {
+    if ( params.parser === 'postcss-js' || exec ) {
         source = this.exec(source, this.resource);
     }
 

--- a/test/cases/exec.js
+++ b/test/cases/exec.js
@@ -1,0 +1,9 @@
+var postcssJs = require('postcss-js');
+
+var style = {
+    a: {
+        color: 'green'
+    }
+};
+
+module.exports = postcssJs.parse(style);

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,13 @@ describe('postcss-loader', function () {
         expect(css).to.eql('a {\n    color: red\n}');
     });
 
+    it('processes CSS with exec', function () {
+        var css = require('!raw-loader!' +
+                          '../?exec!' +
+                          './cases/exec.js');
+        expect(css).to.eql('a {\n    color: green\n}');
+    });
+
     it('inlines map', function () {
         var css = require('!raw-loader!../?sourceMap=inline!./cases/style.css');
         expect(css).to.include('/*# sourceMappingURL=');


### PR DESCRIPTION
An `exec` flag can be provided to the loader query or webpack config. This instructs the loader to load the source using `exec`. This enhances the previous behavior which was to check that the loader query parser was strictly equal to `postcss-js`.

This fixes an issue where the `postcss-js` parser cannot be specified through the webpack postcss config option.

This also enables parsers other than `postcss-js` to receive executed module results.