### PR TITLE
Gracefully handle lack of compilation object

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,11 +83,18 @@ module.exports = function (source, map) {
     }
 
     // Allow plugins to add or remove postcss plugins
-    plugins = this._compilation.applyPluginsWaterfall(
-        'postcss-loader-before-processing',
-        [].concat(plugins),
-        params
-    );
+    if ( this._compilation ) {
+        plugins = this._compilation.applyPluginsWaterfall(
+          'postcss-loader-before-processing',
+          [].concat(plugins),
+          params
+        );
+    } else {
+        loader.emitWarning(
+          'this._compilation is not available thus ' +
+          '`postcss-loader-before-processing` is not supported'
+        );
+    }
 
     postcss(plugins).process(source, opts)
         .then(function (result) {


### PR DESCRIPTION
That way loader will not be fully functional when used with happypack, but at least without a crash.

Before:
```
ERROR in ./main.css
Module build failed: Error: Cannot read property 'applyPluginsWaterfall' of undefined
TypeError: Cannot read property 'applyPluginsWaterfall' of undefined
```

After
```
WARNING in ./main.css
this._compilation is not available thus `postcss-loader-before-processing` is not supported
```
