### PR TITLE
Allow `options` via `query`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function (source, map) {
     if ( typeof map === 'string' ) map = JSON.parse(map);
     if ( map && map.mappings ) opts.map.prev = map;
 
-    var options = this.options.postcss;
+    var options = params.options || this.options.postcss;
     if ( typeof options === 'function' ) {
         options = options.call(this, this);
     }

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function (source, map) {
     if ( typeof map === 'string' ) map = JSON.parse(map);
     if ( map && map.mappings ) opts.map.prev = map;
 
-    var options = params.options || this.options.postcss;
+    var options = params.plugins || this.options.postcss;
     if ( typeof options === 'function' ) {
         options = options.call(this, this);
     }


### PR DESCRIPTION
When `webpack@2` lands there will no longer be any `this.options`. Since query can now be a vanilla object instead of a string, having `options` reside in query is a quick, non-destructive fix.

See:
 * https://github.com/webpack/extract-text-webpack-plugin/pull/266
 * https://github.com/webpack-config/webpack-config-postcss/pull/10