### PR TITLE
Update minimum NodeJS and NPM versions required

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "postcss-loader",
   "version": "1.1.1",
   "description": "PostCSS loader for webpack",
+  "engines": { "node": ">=0.12", "npm": ">=3" },
   "keywords": ["webpack", "loader", "css", "postcss", "postcss-runner"],
   "author": "Andrey Sitnik <andrey@sitnik.ru>",
   "license": "MIT",


### PR DESCRIPTION
This module requires `postcss-load-config` which in turn requires `postcss-load-plugins` and `postcss-load-options`, all three of these repos have a NodeJS & NPM minimum requirement:

• "engines": { "node": ">=0.12", "npm": ">=3" },`

https://github.com/michael-ciniawsky/postcss-load-config/blob/master/package.json#L5
https://github.com/michael-ciniawsky/postcss-load-plugins/blob/master/package.json#L5
https://github.com/michael-ciniawsky/postcss-load-options/blob/master/package.json#L5

To prevent warnings when using this module this repo should also follow the same min req.