### PR TITLE
You can now set custom config path.

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ module.exports = function (source, map) {
     var options  = params.plugins || loader.options.postcss;
     var pack     = params.pack;
     var callback = loader.async();
+    var config_path = params.config ? path.join(process.cwd(), params.config) : path.dirname(file)
 
     Promise.resolve().then(function () {
         if ( typeof options !== 'undefined' ) {
@@ -57,7 +58,7 @@ module.exports = function (source, map) {
                 throw new Error('PostCSS plugin pack is supported ' +
                                 'only when use plugins in webpack config');
             }
-            return loadConfig({ webpack: loader }, path.dirname(file));
+            return loadConfig({ webpack: loader }, config_path);
         }
     }).then(function (config) {
         if ( !config ) config = { };


### PR DESCRIPTION
I personally organize all of my build settings to "build" folder. However, postcss-loader only accepts configuration files in its ancestor folders. 

So, I changed the code to accept the custom configuration path by 
`'postcss?config=./the/path/to/your/config/file/from/the/root',`

 I hope you like it. 