### PR TITLE
Allow absolute path as config option

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,17 @@ module.exports = function (source, map) {
     var options  = params.plugins || loader.options.postcss;
     var pack     = params.pack;
     var callback = loader.async();
-    var configPath = params.config ?
-        path.join(process.cwd(), params.config) : path.dirname(file);
+    var configPath;
+
+    if (params.config) {
+        if (path.isAbsolute(params.config)) {
+            configPath = params.config;
+        } else {
+            configPath = path.join(process.cwd(), params.config);
+        }
+    } else {
+        configPath = path.dirname(file);
+    }
 
     Promise.resolve().then(function () {
         if ( typeof options !== 'undefined' ) {


### PR DESCRIPTION
I'm unable to write a test for it as you compile the tests, so webpack handles the path for you... Ideas?

The test I wrote:
```js
it('allows to change config path with absolute path', function () {
    // eslint-disable-next-line no-path-concat
    var css = require('!raw-loader' +
                      '!../?config=' +
                      __dirname + '/cases/config/postcss.config.js' +
                      '!./cases/style.css');
    expect(css).toEqual('a { color: black }\n');
});
```