### PR TITLE
Adding description of using postcss-js parser with babel 6 compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ export default {
 }
 ```
 
-> If you are using babel 6 compiler and up you need to do the following in order for setup to work
+> If you are using Babel >= v6 you need to do the following in order for the setup to work
 
-> * It is suggested to have only **default** export per style module
-> * You need to add [babel-plugin-add-module-exports] to you configuration
+> 1. Add [babel-plugin-add-module-exports] to your configuration
+> 2. You need to have only one **default** export per style module
 
 If you use JS styles without `postcss-js` parser, you can add `exec` parameter:
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ export default {
 }
 ```
 
+> If you are using babel 6 compiler and up you need to do the following in order for setup to work
+
+> * It is suggested to have only **default** export per style module
+> * You need to add [babel-plugin-add-module-exports] to you configuration
+
 If you use JS styles without `postcss-js` parser, you can add `exec` parameter:
 
 ```js
@@ -196,6 +201,7 @@ If you use JS styles without `postcss-js` parser, you can add `exec` parameter:
 ```
 
 [postcss-js]: https://github.com/postcss/postcss-js
+[babel-plugin-add-module-exports]: https://github.com/59naga/babel-plugin-add-module-exports
 
 ### Dynamic Config
 


### PR DESCRIPTION
postcss-js parser produce wrapped styles, adding description to fix this problem