### PR TITLE
Don't force internal requires of options

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,13 +91,25 @@ module.exports = function (source, map) {
         if ( map && map.mappings ) opts.map.prev = map;
 
         if ( params.syntax ) {
-            opts.syntax = require(params.syntax);
+            if ( typeof params.syntax === 'string' ) {
+                opts.syntax = require(params.syntax);
+            } else {
+                opts.syntax = params.syntax;
+            }
         }
         if ( params.parser ) {
-            opts.parser = require(params.parser);
+            if ( typeof params.parser === 'string' ) {
+                opts.parser = require(params.parser);
+            } else {
+                opts.parser = params.parser;
+            }
         }
         if ( params.stringifier ) {
-            opts.stringifier = require(params.stringifier);
+            if ( typeof params.stringifier === 'string' ) {
+                opts.stringifier = require(params.stringifier);
+            } else {
+                opts.stringifier = params.stringifier;
+            }
         }
 
         var exec = params.exec || config.exec;


### PR DESCRIPTION
Hi there! So I ran into a situation where I need to require the parser myself and pass it in, rather than having it required internally, so I added this option. I couldn't quickly get my head around how the test suite works, but if you give me a push in the right direction I'd be happy to add a test for this. Meanwhile, it is a progressive upgrade, so it won't break any existing functionality.