### PR TITLE
fix: return promise to correctly resolve options after first call

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = function (source, map) {
         configPath = path.dirname(file);
     }
 
-    Promise.resolve().then(function () {
+    return Promise.resolve(function () {
         if ( typeof options !== 'undefined' ) {
             return parseOptions.call(loader, options, pack);
         } else {


### PR DESCRIPTION
when using inlined plugin options (not using `postcss.config.js`) the
first call to the loader would succeed in finding any `options` set,
but subsequent calls would fail.

the fix here changes the loader to return the promise it creates which
seems to allow using an inlined `options.plugins` function again.