### PR TITLE
fix(index): do not delete options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,11 +69,7 @@ module.exports = function loader (css, map) {
       : rc.ctx.options = {}
   }
 
-  delete options.config
-
   const sourceMap = options.sourceMap
-
-  delete options.sourceMap
 
   Promise.resolve().then(() => {
     if (Object.keys(options).length !== 0) {


### PR DESCRIPTION
The deletion of the options object causes
them to be undefined for subsequent uses
of the loader.

Closes https://github.com/postcss/postcss-loader/issues/207