### PR TITLE
cssnext to postcss-cssnext

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ module.exports = ({ file, options, env }) => ({
   parser: file.extname === '.sss' ? 'sugarss' : false,
   plugins: {
     'postcss-import': { root: file.dirname },
-    'cssnext': options.cssnext ? options.cssnext : false,
+    'postcss-cssnext': options.cssnext ? options.cssnext : false,
     'autoprefixer': env == 'production' ? options.autoprefixer : false,
     'cssnano': env === 'production' ? options.cssnano : false
   }


### PR DESCRIPTION
 cssnext@1.8.4: cssnext is now postcss-cssnext. cssnext is deprecated. See postcss-cssnext migration guide http://cssnext.io/postcss/