### PR TITLE
refactor: improved loading algorithm of options and configs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,53 +47,55 @@ module.exports = function loader (css, map) {
 
   validateOptions(require('./options.json'), options, 'PostCSS Loader')
 
-  const rc = {
-    path: path.dirname(file),
-    ctx: {
-      file: {
-        extname: path.extname(file),
-        dirname: path.dirname(file),
-        basename: path.basename(file)
-      },
-      options: {}
-    }
-  }
-
-  if (options.config) {
-    if (options.config.path) {
-      rc.path = path.resolve(options.config.path)
-    }
-
-    if (options.config.ctx) {
-      rc.ctx.options = options.config.ctx
-    }
-  }
-
-  const sourceMap = options.sourceMap
-
   Promise.resolve().then(() => {
-    const length = Object.keys(options).length
+    if (options.exec || options.parser || options.syntax || options.stringifier || options.plugins) {
+      return parseOptions.call(this, options)
+    }
 
-    // TODO
-    // Refactor
-    if (!options.config && !sourceMap && length) {
-      return parseOptions.call(this, options)
-    } else if (options.config && !sourceMap && length > 1) {
-      return parseOptions.call(this, options)
-    } else if (!options.config && sourceMap && length > 1) {
-      return parseOptions.call(this, options)
-    } else if (options.config && sourceMap && length > 2) {
-      return parseOptions.call(this, options)
+    const rc = {
+      path: path.dirname(file),
+      ctx: {
+        file: {
+          extname: path.extname(file),
+          dirname: path.dirname(file),
+          basename: path.basename(file)
+        },
+        options: {}
+      }
+    }
+
+    // Read options from options.config only when options.config is object
+    if (options.config) {
+      if (options.config.path) {
+        rc.path = path.resolve(options.config.path)
+      }
+
+      if (options.config.ctx) {
+        rc.ctx.options = options.config.ctx
+      }
     }
 
     return postcssrc(rc.ctx, rc.path, { argv: false })
-  }).then((config) => {
-    if (!config) config = {}
+      .then((config) => {
+        // Get `sourceMap` option from loader options when no `map` option in `postcss.config.js`
+        if (!config.options.map) config.options.map = options.sourceMap
 
+        return config
+      })
+  }).then((config) => {
     if (config.file) this.addDependency(config.file)
 
+    let sourceMap = config.options.map
     let plugins = config.plugins || []
-    let options = Object.assign({
+
+    // Disable override `to` option
+    if (config.options.to) delete config.options.to
+    // Disable override `from` option
+    if (config.options.from) delete config.options.from
+    // Disable override `map` option
+    if (config.options.map) delete config.options.map
+
+    let postcssOption = Object.assign({
       to: file,
       from: file,
       map: sourceMap
@@ -105,20 +107,20 @@ module.exports = function loader (css, map) {
 
     // Loader Exec (Deprecated)
     // https://webpack.js.org/api/loaders/#deprecated-context-properties
-    if (options.parser === 'postcss-js') {
+    if (postcssOption.parser === 'postcss-js') {
       css = this.exec(css, this.resource)
     }
 
-    if (typeof options.parser === 'string') {
-      options.parser = require(options.parser)
+    if (typeof postcssOption.parser === 'string') {
+      postcssOption.parser = require(postcssOption.parser)
     }
 
-    if (typeof options.syntax === 'string') {
-      options.syntax = require(options.syntax)
+    if (typeof postcssOption.syntax === 'string') {
+      postcssOption.syntax = require(postcssOption.syntax)
     }
 
-    if (typeof options.stringifier === 'string') {
-      options.stringifier = require(options.stringifier)
+    if (typeof postcssOption.stringifier === 'string') {
+      postcssOption.stringifier = require(postcssOption.stringifier)
     }
 
     // Loader API Exec (Deprecated)
@@ -132,10 +134,10 @@ module.exports = function loader (css, map) {
     }
 
     if (sourceMap && typeof map === 'string') map = JSON.parse(map)
-    if (sourceMap && map) options.map.prev = map
+    if (sourceMap && map) postcssOption.map.prev = map
 
     return postcss(plugins)
-      .process(css, options)
+      .process(css, postcssOption)
       .then((result) => {
         result.warnings().forEach((msg) => this.emitWarning(msg.toString()))
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -11,12 +11,11 @@ module.exports = function parseOptions (params) {
   else if (Array.isArray(params.plugins)) plugins = params.plugins
   else plugins = params.plugins
 
-  const options = {}
-
-  if (typeof params !== 'undefined') {
-    options.parser = params.parser
-    options.syntax = params.syntax
-    options.stringifier = params.stringifier
+  const options = {
+    parser: params.parser,
+    syntax: params.syntax,
+    stringifier: params.stringifier,
+    map: params.sourceMap
   }
 
   const exec = params && params.exec

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "docs": "jsdoc2md lib/index.js > LOADER.md",
     "pretest": "npm run lint && npm run test:build",
     "test": "jest",
+    "test-only": "npm run test:build && jest && npm run clean",
     "test:build": "node test/webpack.build.js",
     "posttest": "npm run clean",
     "release": "standard-version"


### PR DESCRIPTION
Why?
1. No todo :smile:
2. Always load config if your pass `config.path`, now it is not working as expected if i pass `config.path` and `sourceMap: false` my config file not loading -> `options.config && !sourceMap && length > 1` (i want to load config and set `sourceMap` use loader options ), also sometimes i want setup some option from options loader.
3. Some perf (we don't create `rc` object because it is not necessary if i use only `options` without `options.config`)
4. Allow to passing options to `postcss` throw `loader.options`, now it is possibly only using `postcss` config.