### PR TITLE
feat(index): add ICSS support (`url()` && `@import`)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,6 +93,14 @@ module.exports = function loader (css, map) {
     if (config.file) this.addDependency(config.file)
 
     let plugins = config.plugins || []
+
+    // Add ICSS Support
+    // url() && @import
+    plugins.concat([
+      require('postcss-icss-url')(),
+      require('postcss-icss-import')()
+    ])
+
     let options = Object.assign({
       to: file,
       from: file,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "loader-utils": "^1.x",
     "postcss": "^6.x",
+    "postcss-icss-import": "^0.x",
+    "postcss-icss-url": "^0.x",
     "postcss-load-config": "^1.x",
     "schema-utils": "^0.x"
   },
@@ -23,7 +25,7 @@
     "jsdoc-to-markdown": "^3.x",
     "postcss-js": "^0.x",
     "standard": "^10.x",
-    "standard-version": "^4.0.0",
+    "standard-version": "^4.x",
     "sugarss": "^1.x",
     "webpack": "^2.x"
   },


### PR DESCRIPTION
Fixes #228 

### Feature

- [x] add [`postcss-icss-url`](https://github.com/css-modules/postcss-icss-url) for `url()` handling
- [x] add [`postcss-icss-import`](https://github.com/css-modules/postcss-icss-import) for `@import` handling

#### `url()`

```css
.url {
   background-url: ('./img.png');
}
```

```css
:import('./img.png'){
  __url_0: default
}

.url {
  background-url: url(__url_0)
}
```

#### `@import`

```css
@import './style.css';
```

```css
:import('./style.css') {
  import: default
}
```

### TODO

- [ ] update README
- [ ] update tests