### PR TITLE
refactor: sanitizing `from` and `to` options (`postcss.config.js`)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -92,6 +92,11 @@ module.exports = function loader (css, map) {
 
     if (config.file) this.addDependency(config.file)
 
+    // Disable override `to` option from `postcss.config.js`
+    if (config.options.to) delete config.options.to
+    // Disable override `from` option from `postcss.config.js`
+    if (config.options.from) delete config.options.from
+
     let plugins = config.plugins || []
     let options = Object.assign({
       to: file,


### PR DESCRIPTION
Based on https://github.com/postcss/postcss-loader/pull/234#issuecomment-308486892