### PR TITLE
fix(index): runaway promise

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -165,7 +165,7 @@ module.exports = function loader (css, map) {
            * @param {String} result Result (JS Module)
            * @param {Object} map    Source Map
            */
-          return cb(null, `module.exports = ${JSON.stringify(css)}`, map)
+          return cb(null, `module.exports = ${JSON.stringify(css)}`, map) || null
         }
         /**
          * @memberof loader
@@ -175,7 +175,7 @@ module.exports = function loader (css, map) {
          * @param {String} css  Result (Raw Module)
          * @param {Object} map  Source Map
          */
-        return cb(null, css, map)
+        return cb(null, css, map) || null
       })
   }).catch((err) => {
     return err.name === 'CssSyntaxError' ? cb(new SyntaxError(err)) : cb(err)


### PR DESCRIPTION
I'm getting a runaway promise warning:
```
Warning: a promise was created in a handler at /Users/jmclean/projects/node-graphql-demo/node_modules/postcss-loader/lib/index.js:173:16 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (/Users/jmclean/projects/node-graphql-demo/node_modules/bluebird/js/release/promise.js:77:14)
```
Seems that the loader returns undefined in certain situations, falling back to null fixes it and seems to be the recommended practice from the Bluebird docs: http://goo.gl/rRqMUw

There was a similar fix, about a year ago. #95