### PR TITLE
feat: recognise `config.options.map` (`options.sourceMap`)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,12 +132,12 @@ module.exports = function loader (css, map) {
       css = this.exec(css, this.resource)
     }
 
-    if (!sourceMap && map) {
+    if (!options.map && map) {
       this.emitWarning(`\n\n ⚠️  PostCSS Loader\n\nPrevious source map found, but options.sourceMap isn't set.\nIn this case the loader will discard the source map entirely for performance reasons.\nSee https://github.com/postcss/postcss-loader#sourcemap for more information.\n\n`)
     }
 
-    if (sourceMap && typeof map === 'string') map = JSON.parse(map)
-    if (sourceMap && map) options.map.prev = map
+    if (options.map && typeof map === 'string') map = JSON.parse(map)
+    if (options.map && map) options.map.prev = map
 
     return postcss(plugins)
       .process(css, options)


### PR DESCRIPTION
Currently loader options can be overridden by config options loaded by postcss-load-config.

So we should use the merged `options.map` here instead of `sourceMap`.