### PR TITLE
docs(README): remove `autoprefixer` from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ module.exports = {
   plugins: {
     'postcss-import': {},
     'postcss-cssnext': {},
-    'autoprefixer': {},
     'cssnano': {}
   }
 }


### PR DESCRIPTION
Prevents throwing the warning "postcss-cssnext found a duplicate plugin ('autoprefixer') in your postcss plugins. This might be inefficient. You should remove 'autoprefixer' from your postcss plugin list since it's already included by postcss-cssnext."