### PR TITLE
test: ident && config not working

### DIFF
--- a/test/options/__snapshots__/config.test.js.snap
+++ b/test/options/__snapshots__/config.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`Options Config - {Object} 1`] = `"module.exports = \\"a { color: rgba(255, 0, 0, 1.0) }\\\\n\\""`;
 
+exports[`Options Config - Context - {Object} - with ident 1`] = `"module.exports = \\"a { color: rgba(255, 0, 0, 1.0) }\\\\n\\""`;
+
 exports[`Options Config - Context - {Object} 1`] = `"module.exports = \\"a { color: rgba(255, 0, 0, 1.0) }\\\\n\\""`;
 
 exports[`Options Config - Path - {String} 1`] = `"module.exports = \\"a { color: black }\\\\n\\""`;

--- a/test/options/config.test.js
+++ b/test/options/config.test.js
@@ -53,4 +53,26 @@ describe('Options', () => {
         expect(src).toMatchSnapshot()
       })
   })
+
+
+  test('Config - Context - {Object} - with ident', () => {
+    const config = {
+      loader: {
+        options: {
+          ident: 'postcss',
+          config: {
+            path: 'test/fixtures/config/postcss.config.js',
+            ctx: { plugin: true }
+          }
+        }
+      }
+    }
+
+    return webpack('css/index.js', config).then((stats) => {
+        const src = loader(stats).src
+
+        expect(src).toEqual("module.exports = \"a { color: rgba(255, 0, 0, 1.0) }\\n\"")
+        expect(src).toMatchSnapshot()
+      })
+  })
 })


### PR DESCRIPTION
Hello,

I was just trying to figure out for a long time now, why my postcss-config is not taken into account, when using postcss-loader with webpack.
I dug into the loader and found this: https://github.com/postcss/postcss-loader/blob/master/lib/index.js#L53-L65, that is why my setup is not working.
Variable length has in this case value of 1, therefore return at line L65 and not using the postcssrc.

```
{
  loader: 'postcss-loader',
  options: {
    sourceMap: true,
    ident: 'postcss',
    config: {
      path: paths.DIR.ROOT,
    },
  },
};
```