### PR TITLE
fix(index): copy loader `options` before modifying

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ const SyntaxError = require('./Error')
  * @return {cb} cb      Result
  */
 module.exports = function loader (css, map) {
-  const options = loaderUtils.getOptions(this) || {}
+  const options = Object.assign({}, loaderUtils.getOptions(this))
 
   validateOptions(require('./options.json'), options, 'PostCSS Loader')
 
@@ -51,7 +51,7 @@ module.exports = function loader (css, map) {
 
   Promise.resolve().then(() => {
     const length = Object.keys(options)
-      .filter((option) =>  {
+      .filter((option) => {
         switch (option) {
           // case 'exec':
           case 'ident':


### PR DESCRIPTION
As per the `loader-utils` documentation ([here](https://github.com/webpack/loader-utils#getoptions)),  the options object should not be modified directly.  Doing so causes the loader parameter of a `plugins` option function to only be run once at the first use of the loader.  This effectively causes the loader parameter to be useless as it cannot be used to retrieve information about the actual resource being used (i.e., `loader.resourcePath`, etc.) instead it will always point to the first resource the loader handled.  This PR makes a copy of the options object returned from `getOptions`.

### `Type`
---

- [X] Fix

### `SemVer`
---

- [X] Bug (:label: Patch)

### `Issues`
---


### `Checklist`
---

- [X] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules