### PR TITLE
feat(index): merge `webpack` and `rc` options (`options.postcssrc`)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,10 @@ const path = require('path')
 const loaderUtils = require('loader-utils')
 
 const parseOptions = require('./options')
+const parseRc = require('./rc')
 const validateOptions = require('schema-utils')
 
 const postcss = require('postcss')
-const postcssrc = require('postcss-load-config')
 
 const SyntaxError = require('./Error')
 
@@ -49,48 +49,18 @@ module.exports = function loader (css, map, meta) {
 
   const sourceMap = options.sourceMap
 
-  Promise.resolve().then(() => {
-    const length = Object.keys(options)
-      .filter((option) => {
-        switch (option) {
-          // case 'exec':
-          case 'ident':
-          case 'config':
-          case 'sourceMap':
-            return
-          default:
-            return option
-        }
-      })
-      .length
-
-    if (length) {
-      return parseOptions.call(this, options)
+  // Parse config from webpack options and rc
+  Promise.all([
+    (options.postcssrc !== false) ? parseRc(file, options) : null,
+    parseOptions(options)
+  ]).then((configs) => {
+    // Merge configs
+    const config = Object.assign({}, configs[0], configs[1])
+    if (configs.every((config) => config && config.plugins)) {
+      config.plugins = configs[0].plugins.concat(configs[1].plugins)
     }
 
-    const rc = {
-      path: path.dirname(file),
-      ctx: {
-        file: {
-          extname: path.extname(file),
-          dirname: path.dirname(file),
-          basename: path.basename(file)
-        },
-        options: {}
-      }
-    }
-
-    if (options.config) {
-      if (options.config.path) {
-        rc.path = path.resolve(options.config.path)
-      }
-
-      if (options.config.ctx) {
-        rc.ctx.options = options.config.ctx
-      }
-    }
-
-    return postcssrc(rc.ctx, rc.path, { argv: false })
+    return config
   }).then((config) => {
     if (!config) config = {}
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,13 +1,10 @@
 'use strict'
 
 module.exports = function parseOptions (params) {
-  if (typeof params.plugins === 'function') {
-    params.plugins = params.plugins.call(this, this)
-  }
-
   let plugins
 
-  if (typeof params.plugins === 'undefined') plugins = []
+  if (typeof params.plugins === 'function') plugins = params.plugins.call(this, this)
+  else if (typeof params.plugins === 'undefined') plugins = []
   else if (Array.isArray(params.plugins)) plugins = params.plugins
   else plugins = [ params.plugins ]
 

--- a/lib/options.json
+++ b/lib/options.json
@@ -32,6 +32,9 @@
         { "instanceof": "Function" }
       ]
     },
+    "postcssrc": {
+      "type": "boolean"
+    },
     "sourceMap": {
       "type": [ "string", "boolean" ]
     }

--- a/lib/rc.js
+++ b/lib/rc.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const path = require('path')
+const postcssrc = require('postcss-load-config')
+
+module.exports = function parseRc (file, options) {
+  const rc = {
+    path: path.dirname(file),
+    ctx: {
+      file: {
+        extname: path.extname(file),
+        dirname: path.dirname(file),
+        basename: path.basename(file)
+      },
+      options: {}
+    }
+  }
+
+  if (options.config) {
+    if (options.config.path) {
+      rc.path = path.resolve(options.config.path)
+    }
+
+    if (options.config.ctx) {
+      rc.ctx.options = options.config.ctx
+    }
+  }
+
+  return Promise.resolve().then(() => {
+    return postcssrc(rc.ctx, rc.path, { argv: false })
+  })
+}

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -9,7 +9,8 @@ describe('Loader', () => {
     const config = {
       loader: {
         options: {
-          plugins: []
+          plugins: [],
+          postcssrc: false
         }
       }
     }

--- a/test/options/__snapshots__/config.test.js.snap
+++ b/test/options/__snapshots__/config.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Options Config - {Object} - with postcssrc false 1`] = `"module.exports = \\"a { color: black }\\\\n\\""`;
+
 exports[`Options Config - {Object} 1`] = `"module.exports = \\"a { color: rgba(255, 0, 0, 1.0) }\\\\n\\""`;
 
 exports[`Options Config - Context - {Object} - with ident 1`] = `"module.exports = \\"a { color: rgba(255, 0, 0, 1.0) }\\\\n\\""`;
@@ -7,3 +9,5 @@ exports[`Options Config - Context - {Object} - with ident 1`] = `"module.exports
 exports[`Options Config - Context - {Object} 1`] = `"module.exports = \\"a { color: rgba(255, 0, 0, 1.0) }\\\\n\\""`;
 
 exports[`Options Config - Path - {String} 1`] = `"module.exports = \\"a { color: black }\\\\n\\""`;
+
+exports[`Options Config - with bad option 1`] = `"module.exports = \\"a { color: black }\\\\n\\""`;

--- a/test/options/config.test.js
+++ b/test/options/config.test.js
@@ -17,6 +17,23 @@ describe('Options', () => {
       })
   })
 
+  test('Config - {Object} - with postcssrc false', () => {
+    const config = {
+      loader: {
+        options: {
+          postcssrc: false
+        }
+      }
+    }
+
+    return webpack('css/index.js', config).then((stats) => {
+        const src = loader(stats).src
+
+        expect(src).toEqual("module.exports = \"a { color: black }\\n\"")
+        expect(src).toMatchSnapshot()
+      })
+  })
+
   test('Config - Path - {String}', () => {
     const config = {
       loader: {
@@ -72,6 +89,24 @@ describe('Options', () => {
         const src = loader(stats).src
 
         expect(src).toEqual("module.exports = \"a { color: rgba(255, 0, 0, 1.0) }\\n\"")
+        expect(src).toMatchSnapshot()
+      })
+  })
+
+  test('Config - with bad option', () => {
+    const config = {
+      loader: {
+        options: {
+          unsupportedOption: true,
+          postcssrc: false
+        }
+      }
+    }
+
+    return webpack('css/index.js', config).then((stats) => {
+        const src = loader(stats).src
+
+        expect(src).toEqual("module.exports = \"a { color: black }\\n\"")
         expect(src).toMatchSnapshot()
       })
   })

--- a/test/options/parser.test.js
+++ b/test/options/parser.test.js
@@ -8,7 +8,8 @@ describe('Options', () => {
     const config = {
       loader: {
         options: {
-          parser: 'sugarss'
+          parser: 'sugarss',
+          postcssrc: false
         }
       }
     }
@@ -26,7 +27,8 @@ describe('Options', () => {
       loader: {
         options: {
           ident: 'postcss',
-          parser: require('sugarss')
+          parser: require('sugarss'),
+          postcssrc: false
         }
       }
     }

--- a/test/options/stringifier.test.js
+++ b/test/options/stringifier.test.js
@@ -8,7 +8,8 @@ describe('Options', () => {
     const config = {
       loader: {
         options: {
-          stringifier: 'sugarss'
+          stringifier: 'sugarss',
+          postcssrc: false
         }
       }
     }
@@ -26,7 +27,8 @@ describe('Options', () => {
       loader: {
         options: {
           ident: 'postcss',
-          stringifier: require('sugarss')
+          stringifier: require('sugarss'),
+          postcssrc: false
         }
       }
     }

--- a/test/options/syntax.test.js
+++ b/test/options/syntax.test.js
@@ -8,7 +8,8 @@ describe('Options', () => {
     const config = {
       loader: {
         options: {
-          syntax: 'sugarss'
+          syntax: 'sugarss',
+          postcssrc: false
         }
       }
     }
@@ -26,7 +27,8 @@ describe('Options', () => {
       loader: {
         options: {
           ident: 'postcss',
-          syntax: require('sugarss')
+          syntax: require('sugarss'),
+          postcssrc: false
         }
       }
     }


### PR DESCRIPTION
*Some background:*

I recently upgraded from 1.3.3 to 2.1.1. It broke my build and it took me some time to figure out why. It turns out that I had a bad option `sourceComments` passed to postcss-loader, which probably had been hanging around since a previous switch from sass to postcss. The extra option would cause postcss-loader to skip postcss.config.js entirely because of options length-check in `index.js`:

https://github.com/postcss/postcss-loader/blob/1e0cade20890a150e2187172616ffb523cb17bab/lib/index.js#L67-L69

The options passes validation because additionalProperties is set to true in `options.json`.

*Proposed change*

The problem above could probably be solved by setting additionalProperties to false. But it seems to me that the expected thing to do here is to merge the option sources (both webpack and postcss.config.js), just like babel-loader. This does not only solve the background problem, but is also a handy feature.

*Change*

* Add boolean postcssrc option that control wheather or not to parse and
use postcss.config.js
* Merge options from webpack with the options defined in
postcss.config.js
* Update some tests with postcssrc option set to false when it was
expected
* Add tests for postcssrc option and a test for unknown options

Any thoughts?

### `Type`
---

- [X] Feature
- [X] Refactor

### `SemVer`
---

- [x] Breaking Change (:label: Major)

### `Checklist`
---

- [X] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
