### PR TITLE
fix(options): disallow additional properties and add `ident` to validation

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -16,6 +16,9 @@
     "exec": {
       "type": "boolean"
     },
+    "ident": {
+      "type": "string"
+    },
     "parser": {
       "type": [ "string", "object" ]
     },
@@ -36,5 +39,5 @@
       "type": [ "string", "boolean" ]
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }


### PR DESCRIPTION
Prevents unsupported options in webpack config. Unknown properties will cause a compilation error:

```
Module build failed: ValidationError: PostCSS Loader Invalid Options

options['other'] is an invalid additional property
```

### `Type`
---

- [X] Fix
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Feature
- [ ] Refactor

### `SemVer`
---

- [X] Bug (:label: Patch)
- [ ] Feature (:label: Minor)
- [ ] Breaking Change (:label: Major)

### `Checklist`
---

- [X] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
