### PR TITLE
feat(index): expose `options` as a  `{Function}` (`options.parser`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ You can use a dynamic setup similar to the one listed in the [`ctx` section](#co
   test: /\.[cs]ss$/,
   use: [
     ...,
-    { loader: 'postcss-loader', options: { parser: (css, opts) => opts.from.match(/\.sss$/) ? sugarss.parse(css) : css } }
+    { loader: 'postcss-loader', options: { parser: (css, opts) => opts.from.match(/\.sss$/) ? sugarss.parse(css) : postcss.parse(css) } }
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ module.exports = {
 |Name|Type|Default|Description|
 |:--:|:--:|:-----:|:----------|
 |[`exec`](#exec)|`{Boolean}`|`undefined`|Enable PostCSS Parser support in `CSS-in-JS`|
-|[`parser`](#syntaxes)|`{String\|Object}`|`undefined`|Set PostCSS Parser|
+|[`parser`](#syntaxes)|`{String\|Object|Function}`|`undefined`|Set PostCSS Parser|
 |[`syntax`](#syntaxes)|`{String\|Object}`|`undefined`|Set PostCSS Syntax|
 |[`stringifier`](#syntaxes)|`{String\|Object}`|`undefined`|Set PostCSS Stringifier|
 |[`config`](#config)|`{Object}`|`undefined`|Set `postcss.config.js` config path && `ctx`|
@@ -234,6 +234,19 @@ module.exports = ({ file, options, env }) => ({
   use: [
     ...,
     { loader: 'postcss-loader', options: { parser: 'sugarss' } }
+  ]
+}
+```
+
+You can use a dynamic setup similar to the one listed in the [`ctx` section](#context-ctx) by passing a function
+
+**webpack.config.js**
+```js
+{
+  test: /\.[cs]ss$/,
+  use: [
+    ...,
+    { loader: 'postcss-loader', options: { parser: (css, opts) => opts.from.match(/\.sss$/) ? sugarss.parse(css) : css } }
   ]
 }
 ```

--- a/lib/options.json
+++ b/lib/options.json
@@ -20,7 +20,11 @@
       "type": "string"
     },
     "parser": {
-      "type": [ "string", "object" ]
+      "anyOf": [
+        { "type": "string" },
+        { "type": "object" },
+        { "instanceof": "Function" }
+      ]
     },
     "syntax": {
       "type": [ "string", "object" ]

--- a/test/options/parser.test.js
+++ b/test/options/parser.test.js
@@ -39,3 +39,30 @@ describe('Options', () => {
       })
   })
 })
+
+test('Parser - {Function}', () => {
+  const config = {
+    loader: {
+      options: {
+        ident: 'postcss',
+        parser: (css, opts) => opts.from.match(/\.sss$/)
+          ? require('sugarss').parse(css)
+          : require('postcss').parse(css)
+      }
+    }
+  }
+
+  return webpack('sss/index.js', config).then((stats) => {
+      const src = loader(stats).src
+
+      expect(src).toEqual("module.exports = \"a {\\n  color: black\\n}\\n\"")
+      expect(src).toMatchSnapshot()
+
+      return webpack('css/index.js', config).then((stats) => {
+        const src = loader(stats).src
+  
+        expect(src).toEqual("module.exports = \"a { color: black }\\n\"")
+        expect(src).toMatchSnapshot()
+      })
+    })
+})


### PR DESCRIPTION
Fixes issue #351, adding support for `parser` to be a function, as mentioned in the existing documentation.

### `Type`
---

- [x] Feature

### `SemVer`
---

- [x] Feature (:label: Minor)

### `Issues`
---

- Fixes #351

### `Checklist`
---

- [x] Lint and unit tests pass with my changes
- [x] I have added tests that prove my fix is effective/works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes are merged and published in downstream modules
