### PR TITLE
fix(index): remove `sourceMap` warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,6 @@ module.exports = ({ file, options, env }) => ({
 
 Enables source map support, `postcss-loader` will use the previous source map given by other loaders and update it accordingly, if no previous loader is applied before `postcss-loader`, the loader will generate a source map for you.
 
-> :warning: If a previous loader like e.g `sass-loader` is applied and it's `sourceMap` option is set, but the `sourceMap` option in `postcss-loader` is omitted, previous source maps will be discarded by `postcss-loader` **entirely**.
-
 **webpack.config.js**
 ```js
 {

--- a/lib/index.js
+++ b/lib/index.js
@@ -137,10 +137,6 @@ module.exports = function loader (css, map, meta) {
       css = this.exec(css, this.resource)
     }
 
-    if (!sourceMap && sourceMap !== false && map) {
-      this.emitWarning(`\n\n ⚠️  PostCSS Loader\n\nPrevious source map found, but options.sourceMap isn't set.\nIn this case the loader will discard the source map entirely for performance reasons.\nSee https://github.com/postcss/postcss-loader#sourcemap for more information.\n\n`)
-    }
-
     if (sourceMap && typeof map === 'string') map = JSON.parse(map)
     if (sourceMap && map) options.map.prev = map
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -137,7 +137,7 @@ module.exports = function loader (css, map, meta) {
       css = this.exec(css, this.resource)
     }
 
-    if (!sourceMap && map) {
+    if (!sourceMap && sourceMap !== false && map) {
       this.emitWarning(`\n\n ⚠️  PostCSS Loader\n\nPrevious source map found, but options.sourceMap isn't set.\nIn this case the loader will discard the source map entirely for performance reasons.\nSee https://github.com/postcss/postcss-loader#sourcemap for more information.\n\n`)
     }
 


### PR DESCRIPTION
> ℹ️  Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.

Currently as long as there is a source map passed from an upstream loader (e.g. `vue-loader`), `postcss-loader` warns about sourceMap being discarded even when the `sourceMap` option is explicitly set to `false`. It should only warn when the option is "not set".

### `Type`
---

> ℹ️  What types of changes does your code introduce?

> _Put an `x` in the boxes that apply_

- [x] Fix
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Feature
- [ ] Refactor

### `SemVer`
---

> ℹ️  What changes to the current `semver` range does your PR introduce?

> _Put an `x` in the boxes that apply_

- [x] Bug (:label: Patch)
- [ ] Feature (:label: Minor)
- [ ] Breaking Change (:label: Major)

### `Issues`
---

> ℹ️  What issue (if any) are closed by your PR?

> _Replace `#1` with the error number that applies_

N/A

### `Checklist`
---

> ℹ️  You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is a reminder of what we are going to look for before merging your code.

> _Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
