### PR TITLE
fix(index): emit `warnings` as an instance of `{Error}` instead of `{String}`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -143,7 +143,7 @@ module.exports = function loader (css, map, meta) {
     return postcss(plugins)
       .process(css, options)
       .then((result) => {
-        result.warnings().forEach((msg) => this.emitWarning(msg.toString()))
+        result.warnings().forEach((msg) => this.emitWarning(new Error(msg.toString())))
 
         result.messages.forEach((msg) => {
           if (msg.type === 'dependency') this.addDependency(msg.file)


### PR DESCRIPTION
Warnings are currently sent to webpack as strings. However, Webpack's emitWarning function expects an error, [as described in their API](https://webpack.js.org/api/loaders/#this-emitwarning). This results in the errors described in #350. This PR simply changes the warnings emitted by postcss-loader from strings to an error instance.

### `Type`
---

- [x] Fix

### `SemVer`
---

- [x] Bug (:label: Patch)

### `Issues`
---

- Fixes #350

### `Checklist`
---

> ℹ️  You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is a reminder of what we are going to look for before merging your code.

> _Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
