### PR TITLE
docs(README): clarify `path` option description (`options.config.path`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If you use JS styles without the [`postcss-js`][postcss-js] parser, add the `exe
 
 You can manually specify the path to search for your config (`postcss.config.js`) with the `config.path` option. This is needed if you store your config  in a separate e.g `./config || ./.config` folder.
 
-> ⚠️  Otherwise it is **unnecessary** to set this option and is **not** recommended. You **can't** set other name for **postcss.config.js**, this option only allows you to specify the folder where it will be looked for.
+> ⚠️  Note that you **can't** use a **filename** other than the [supported config formats] (e.g `.postcssrc.js`, `postcss.config.js`), this option only allows you to manually specify the **directory** where config lookup should **start** from
 
 **webpack.config.js**
 ```js
@@ -152,11 +152,14 @@ You can manually specify the path to search for your config (`postcss.config.js`
   loader: 'postcss-loader',
   options: {
     config: {
-      path: 'path/to/postcss.config.js'
+      path: 'path/to/.config/' ✅
+      path: 'path/to/.config/css.config.js' ❌
     }
   }
 }
 ```
+
+[supported config formats]: https://github.com/michael-ciniawsky/postcss-load-config#usage
 
 #### `Context (ctx)`
 

--- a/README.md
+++ b/README.md
@@ -137,14 +137,14 @@ If you use JS styles without the [`postcss-js`][postcss-js] parser, add the `exe
 
 |Name|Type|Default|Description|
 |:--:|:--:|:-----:|:----------|
-|[`path`](#path)|`{String}`|`undefined`|PostCSS Config Path|
+|[`path`](#path)|`{String}`|`undefined`|PostCSS Config Directory|
 |[`context`](#context)|`{Object}`|`undefined`|PostCSS Config Context|
 
 #### `Path`
 
 You can manually specify the path to search for your config (`postcss.config.js`) with the `config.path` option. This is needed if you store your config  in a separate e.g `./config || ./.config` folder.
 
-> ⚠️  Otherwise it is **unnecessary** to set this option and is **not** recommended
+> ⚠️  Otherwise it is **unnecessary** to set this option and is **not** recommended. You **can't** set other name for **postcss.config.js**, this option only allows you to specify the folder where it will be looked for.
 
 **webpack.config.js**
 ```js

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ If you use JS styles without the [`postcss-js`][postcss-js] parser, add the `exe
 
 You can manually specify the path to search for your config (`postcss.config.js`) with the `config.path` option. This is needed if you store your config  in a separate e.g `./config || ./.config` folder.
 
+> ⚠️  Otherwise it is **unnecessary** to set this option and is **not** recommended
+
 > ⚠️  Note that you **can't** use a **filename** other than the [supported config formats] (e.g `.postcssrc.js`, `postcss.config.js`), this option only allows you to manually specify the **directory** where config lookup should **start** from
 
 **webpack.config.js**


### PR DESCRIPTION
The description for `path` option in **README.md** is a bit misleading. It says `PostCSS Config Path` while in fact it sets only the directory where **postcss.config.js** will be looked for. 

It leads to a confusion, because users may think that they can set arbitrary name for their config file.

### `Type`
---
- [x] Docs

### `SemVer`
---
- [x] Bug (:label: Patch)

### `Issues`
---

### `Checklist`
---

- [x] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules